### PR TITLE
Add Unifi Cloud Key Support

### DIFF
--- a/unifi_ssl_import.sh
+++ b/unifi_ssl_import.sh
@@ -35,6 +35,11 @@ KEYSTORE=${UNIFI_DIR}/data/keystore
 #JAVA_DIR=/usr/lib/unifi
 #KEYSTORE=${UNIFI_DIR}/keystore
 
+# Uncomment following three lines for Unifi Cloud Key
+#UNIFI_DIR=/usr/lib/unifi
+#JAVA_DIR=${UNIFI_DIR}
+#KEYSTORE=${UNIFI_DIR}/data/keystore
+
 # FOR LET'S ENCRYPT SSL CERTIFICATES ONLY
 # Generate your Let's Encrtypt key & cert with certbot before running this script
 LE_MODE=no


### PR DESCRIPTION
The paths for JAVA_DIR and KEYSTORE on the Unifi Cloud Key as same as on CentOS.
But UNIFI_DIR is moved to /usr/lib/unifi where the data folder is linked to /srv/unifi/data.