### PR TITLE
Update unifi_ssl_import.sh

### DIFF
--- a/unifi_ssl_import.sh
+++ b/unifi_ssl_import.sh
@@ -124,11 +124,21 @@ fi
 # Export your existing SSL key, cert, and CA data to a PKCS12 file
 printf "\nExporting SSL certificate and key data into temporary PKCS12 file...\n"
 
-openssl pkcs12 -export \
--in ${CHAIN_FILE} \
--inkey ${PRIV_KEY} \
--out ${P12_TEMP} -passout pass:${PASSWORD} \
--name ${ALIAS}
+#If there is a signed crt we should include this in the export
+if [ -f ${SIGNED_CRT} ]; then
+    openssl pkcs12 -export \
+    -in ${CHAIN_FILE} \
+    -in ${SIGNED_CRT} \
+    -inkey ${PRIV_KEY} \
+    -out ${P12_TEMP} -passout pass:${PASSWORD} \
+    -name ${ALIAS}
+else
+    openssl pkcs12 -export \
+    -in ${CHAIN_FILE} \
+    -inkey ${PRIV_KEY} \
+    -out ${P12_TEMP} -passout pass:${PASSWORD} \
+    -name ${ALIAS}
+fi
 	
 # Delete the previous certificate data from keystore to avoid "already exists" message
 printf "\nRemoving previous certificate data from UniFi keystore...\n"
@@ -142,6 +152,7 @@ keytool -importkeystore \
 -destkeystore ${KEYSTORE} \
 -deststorepass ${PASSWORD} \
 -destkeypass ${PASSWORD} \
+-deststoretype pkcs12 \
 -alias ${ALIAS} -trustcacerts
 
 # Clean up temp files


### PR DESCRIPTION
Amending last PR Merge.

The changes added previous streamlined the Let's Encrypt Process but in the process broke the script for user using their own certs. Resulting in errors:
- "No Certificate matches private key"
- "Alias <unifi> does not exist"
etc

Now the script should check if the signed cert exists, if it does add that to the export. (alternative would be to create a combined file, but I personally prefer to keep CA and CRT seperate)

Also added the "deststoretype" option as controller was complaining about security.

Feel free to optimise.