### PR TITLE
Should quote filenames used in tests to avoid empty case

### DIFF
--- a/unifi_ssl_import.sh
+++ b/unifi_ssl_import.sh
@@ -84,7 +84,7 @@ if [ ${LE_MODE} == "true" ]; then
 fi
 
 # Verify required files exist
-if [ ! -f ${PRIV_KEY} ] || [ ! -f ${CHAIN_FILE} ]; then
+if [ ! -f "${PRIV_KEY}" ] || [ ! -f "${CHAIN_FILE}" ]; then
 	printf "\nMissing one or more required files. Check your settings.\n"
 	exit 1
 else
@@ -125,7 +125,7 @@ fi
 printf "\nExporting SSL certificate and key data into temporary PKCS12 file...\n"
 
 #If there is a signed crt we should include this in the export
-if [ -f ${SIGNED_CRT} ]; then
+if [ -f "${SIGNED_CRT}" ]; then
     openssl pkcs12 -export \
     -in ${CHAIN_FILE} \
     -in ${SIGNED_CRT} \


### PR DESCRIPTION
If variables used in tests for file existence are empty, they can lead to false positives. For example, commenting out SIGNED_CERT in the default script will cause `if [ -f $SIGNED_CERT]` to return true. Adding quotes around the variable avoids this issue.