### PR TITLE
remove deststoretype option from keytool import; fixes #35

### DIFF
--- a/unifi_ssl_import.sh
+++ b/unifi_ssl_import.sh
@@ -152,7 +152,6 @@ keytool -importkeystore \
 -destkeystore ${KEYSTORE} \
 -deststorepass ${PASSWORD} \
 -destkeypass ${PASSWORD} \
--deststoretype pkcs12 \
 -alias ${ALIAS} -trustcacerts
 
 # Clean up temp files


### PR DESCRIPTION
 Import failed with PKCS12 specified. Tested with JKS specified, which worked. Also worked when unspecified, so maybe that will be more universal. Otherwise, a check for the type of the destination store might be necessary. All testing done with UniFi Controller version 5.9.29-11384-1 on Ubuntu Server 18.04.1