### PR TITLE
Add unit files for automatic SSL certificate imports

### DIFF
--- a/startup-scripts/unifi_ssl_import.service
+++ b/startup-scripts/unifi_ssl_import.service
@@ -1,0 +1,19 @@
+# unifi_ssl_import.service
+#
+# Usage: copy to (e.g.) /etc/systemd/system/unifi_ssl_import.service
+#        systemctl enable unifi_ssl_import.service
+#        systemctl start unifi_ssl_import.service
+#        systemctl status unifi_ssl_import.service
+#
+[Unit]
+Description= UniFi Controller SSL Certificate Import
+Documentation= https://www.stevejenkins.com/blog/2016/06/use-existing-ssl-certificate-linux-unifi-controller/
+
+[Service]
+Type= simple
+User=
+
+ExecStart= /usr/local/bin/unifi_ssl_import.sh
+
+[Install]
+WantedBy= unifi.service

--- a/startup-scripts/unifi_ssl_import.timer
+++ b/startup-scripts/unifi_ssl_import.timer
@@ -1,0 +1,20 @@
+# unifi_ssl_import.timer
+#
+# Usage: copy to (e.g.) /etc/systemd/system/unifi_ssl_import.timer
+#        systemctl enable unifi_ssl_import.timer
+#        systemctl start unifi_ssl_import.timer
+#        systemctl status unifi_ssl_import.timer
+#
+# Note: Update the OnCalendar entries to about five minutes past when
+#       Let's Encrypt's certbot runs 
+#       (c.f. /etc/systemd/system/snap.certbot.renew.timer)
+[Unit]
+Description=Timer import renewed certificates for UniFi controller
+
+[Timer]
+Unit=unifi_ssl_import.service
+OnCalendar=*-*-* 02:08
+OnCalendar=*-*-* 12:37
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Add systemd unit files for a service that starts before the UniFi controller, and a timer that automatically runs the unifi_ssl_import.sh script.